### PR TITLE
fix cronjob error

### DIFF
--- a/k8s/job-definition-template.ytpl
+++ b/k8s/job-definition-template.ytpl
@@ -15,10 +15,6 @@ spec:
           serviceAccountName: emr-eks-cost-tracking-sa
           restartPolicy: OnFailure
           automountServiceAccountToken: false
-          securityContext:
-            runAsUser: 10001
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
           containers:
           - name: emr-eks-cost-exporter
             image: ECR_IMAGE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
when using the script `deploy-emr-eks-cost-tracking.sh REGION 2.3.3 EKS_CLUSTER ACCOUNTID` to deploy the artifact, there is an exception from CronJob API: 

```
CronJob in version "v1" cannot be handled as a CronJob: strict decoding error: unknown field "spec.jobTemplate.spec.template.spec.securityContext.allowPrivilegeEscalation"
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
